### PR TITLE
fix(android): Reset open URL intent on app restart

### DIFF
--- a/src/universal-links/index-common.ts
+++ b/src/universal-links/index-common.ts
@@ -22,8 +22,8 @@ export class UniversalLink {
 
 let universalLink: UniversalLink | undefined;
 
-export function setUniversalLink(link: string) {
-    universalLink = new UniversalLink(link);
+export function setUniversalLink(link?: string) {
+    universalLink = link != null ? new UniversalLink(link) : undefined;
 }
 
 export function getUniversalLink() {

--- a/src/universal-links/index.android.ts
+++ b/src/universal-links/index.android.ts
@@ -6,18 +6,26 @@ Application.android.on(AndroidApplication.activityNewIntentEvent, (args) => {
     const intent: android.content.Intent = args.activity.getIntent();
     try {
         const data = intent.getData();
-        if (data) {
-            setUniversalLink(data.toString());
-            intent.setData(null);
+        if (!data) {
+            return; // nothing to do
+        }
 
-            const callback = getRegisteredCallback();
-            if (callback) {
-                callback(getUniversalLink());
-            }
-        } else {
-            setUniversalLink();
+        setUniversalLink(data.toString());
+        const callback = getRegisteredCallback();
+        if (callback) {
+            callback(getUniversalLink());
         }
     } catch (e) {
         console.error(e);
+    }
+});
+
+Application.android.on(AndroidApplication.activityDestroyedEvent, (args) => {
+    const intent: android.content.Intent = args.activity.getIntent();
+    const data = intent.getData();
+
+    if (data) {
+        intent.setData(null);
+        setUniversalLink();
     }
 });

--- a/src/universal-links/index.android.ts
+++ b/src/universal-links/index.android.ts
@@ -6,11 +6,17 @@ Application.android.on(AndroidApplication.activityNewIntentEvent, (args) => {
     const intent: android.content.Intent = args.activity.getIntent();
     try {
         const data = intent.getData();
-        if (!data) return; // nothing to do
+        if (data) {
+            setUniversalLink(data.toString());
+            intent.setData(null);
 
-        setUniversalLink(data.toString());
-        const callback = getRegisteredCallback();
-        if (callback) callback(getUniversalLink());
+            const callback = getRegisteredCallback();
+            if (callback) {
+                callback(getUniversalLink());
+            }
+        } else {
+            setUniversalLink();
+        }
     } catch (e) {
         console.error(e);
     }


### PR DESCRIPTION
After some time of testing, it seems plugin is unfriendly in the case of android devices.
To be more specific, if I open app from URL then close it and reopen it, activity will have still kept open URL intent old data stored.

Steps to reproduce:
1) Open app from URL
2) Close app (e.g. back press)
3) Re-open app
4) Method `getUniversalLinks` will return url from previous launch.

Afterwards, app will still think there is an open URL intent.
There is also an issue in stackoverflow regarding this: https://stackoverflow.com/questions/34311501/how-to-clear-intent-data-in-activity-after-open-from-url

My patch unsets universalLinks variable and intent data when activity is destroyed, so that open URL intention is reset after app restart.
This is an improvement for android (I haven't gotten a full picture of how it works in iOS as the concept of app exit is different there).